### PR TITLE
Changes peerDependencies to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ karma-es6-shim
 ==============
 [![npm version](https://badge.fury.io/js/karma-es6-shim.svg)](https://www.npmjs.com/package/karma-es6-shim)
 [![Dependency Status](https://david-dm.org/radify/karma-es6-shim.svg)](https://david-dm.org/radify/karma-es6-shim)
-[![peerDependency Status](https://david-dm.org/radify/karma-es6-shim/peer-status.svg)](https://david-dm.org/radify/karma-es6-shim#info=peerDependencies)
 
 Karma wrapper that makes sure the ES6 and ES5 shims are BOTH available. See also the [example usage project](https://github.com/radify/karma-es6-shim-example).
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "shim"
   ],
   "peerDependencies": {
-    "es5-shim": "~4.1.1",
-    "es6-shim": "~0.28.1"
+    "es5-shim": "~4.1.10",
+    "es6-shim": "~0.33.0"
   },
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "es6-shim",
     "shim"
   ],
-  "peerDependencies": {
+  "dependencies": {
     "es5-shim": "~4.1.10",
     "es6-shim": "~0.33.0"
   },


### PR DESCRIPTION
## Changes peerDependencies to dependencies
- Per @nateabele's suggestion, switches the peerDependencies to ordinary dependencies. 
- Updates them to their current version
- Removes "peerDependencies" David badge from `README`. 
- This problem was raised in issue #4. 
