### PR TITLE
Fix Readme Link To Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example usage
 
 You will almost certainly need some kind of transpiler such as [Babel or 6to5](https://babeljs.io/).
 
-We have supplied an example repository at [https://github.com/radify/karma-es6-shim-example](github.com/radify/karma-es6-shim-example).
+We have supplied an example repository at [https://github.com/radify/karma-es6-shim-example](https://github.com/radify/karma-es6-shim-example).
 
 When to use this and when not to
 --------------------------------


### PR DESCRIPTION
When users click on the example link it currently goes to this URL:

<img width="802" alt="screen shot 2016-05-31 at 4 34 41 pm" src="https://cloud.githubusercontent.com/assets/246603/15693849/b1d1ba9c-274d-11e6-9c92-5d0486182117.png">
